### PR TITLE
The package fails to load in Atom due to snippets cson quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "cson-safe": "^1.0.4"
+  }
 }

--- a/snippets/raml.cson
+++ b/snippets/raml.cson
@@ -1,7 +1,7 @@
 '.source.raml':
   'get':
     'prefix': 'get'
-    'body': """get:
+    'body': '''get:
               	description: |
               		Retrieve resource
               	responses:
@@ -9,10 +9,10 @@
               			description: |
               				Succesfully retrieved resource
               ${1:}
-            """
+            '''
   'delete':
     'prefix': 'delete'
-    'body': """delete:
+    'body': '''delete:
               	description: |
               		Delete resource
               	responses:
@@ -20,19 +20,19 @@
               			description: |
               				Succesfully deleted resource
               ${1:}
-              """
+              '''
   'RAML':
     'prefix': '#%'
-    'body': """#%RAML 0.8
+    'body': '''#%RAML 0.8
                ---
                title: title
                version: version
                baseUri: https://baseUri/version/
                ${1:}
-            """
+            '''
   'patch':
     'prefix': 'patch'
-    'body': """patch:
+    'body': '''patch:
               	description: |
               		Update a field of a resource
               	body:
@@ -41,10 +41,10 @@
               		204:
               			description: Succesfully updated resource
               ${1:}
-            """
+            '''
   'post':
     'prefix': 'post'
-    'body': """post:
+    'body': '''post:
               	description: |
               		Create a new resource
               	body:
@@ -60,10 +60,10 @@
               					type: string
               					required: false
               ${1:}
-            """
+            '''
   'put':
     'prefix': 'put'
-    'body': """put:
+    'body': '''put:
               	description: |
               		Update an existing resource
               	body:
@@ -73,13 +73,13 @@
               			description: |
               				Succesfully updated the resource
               ${1:}
-            """
+            '''
 
   'documentation':
     'prefix': 'documentation'
-    'body': """documentation:
+    'body': '''documentation:
               	- title: title
               		content: |
               			content
               ${1:}
-            """
+            '''

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -1,0 +1,8 @@
+CSON = require 'cson-safe'
+fs = require 'fs'
+
+describe 'Snippets', ->
+  it 'can be parsed without errors', ->
+    expect(
+      -> CSON.parse fs.readFileSync(__dirname + '/../snippets/raml.cson')
+    ).not.toThrow()


### PR DESCRIPTION
The `snippets/raml.cson` uses double quotes, which are not allowed by the `cson-safe` package used by Atom, generating the following error:

![screenshot 2015-01-24 11 27 10](https://cloud.githubusercontent.com/assets/1102266/5887765/c9ee1f32-a3c1-11e4-9d37-368aeca1bce4.png)

This pull request changes the quotes to simple, and also adds a Jasmine spec (to run: View>Developer>Run Package Specs).

